### PR TITLE
Fix out of bounds array access when getting current texture

### DIFF
--- a/Source/Minerals/StaticMineral.cs
+++ b/Source/Minerals/StaticMineral.cs
@@ -594,11 +594,10 @@ namespace Minerals
 				{
 					numToPrint = 1;
 				}
-                currentTextureIndex = 0;
 				for (int i = 0; i < numToPrint; i++)
 				{
                     printSubTexture(layer, i, sizeFactor);
-                    currentTextureIndex += 1;
+                    currentTextureIndex = i;
 				}
 			}
 


### PR DESCRIPTION
Fixes https://github.com/skyarkhangel/Hardcore-SK/issues/2351
Currently, the cached index is always 1 position ahead, causing `System.IndexOutOfRangeException` when [trying to access](https://github.com/zachary-foster/Minerals/blob/af59a34fe0b3517e52c3f87e7ff82e61686ca047/Source/Minerals/StaticMineral.cs#L428) the latest `textureIndexes`'s index.